### PR TITLE
Move try statement outside #if block

### DIFF
--- a/HUX/Scripts/Speech/KeywordManager.cs
+++ b/HUX/Scripts/Speech/KeywordManager.cs
@@ -253,8 +253,8 @@ namespace HUX.Speech
                     return;
                 }
 
-#if UNITY_WSA || UNITY_STANDALONE_WIN
                 try {
+#if UNITY_WSA || UNITY_STANDALONE_WIN
                     m_Recognizer = new KeywordRecognizer(new string[] { keyword });
                     m_Recognizer.OnPhraseRecognized += OnPhraseRecognized;
 


### PR DESCRIPTION
with the try{ statement inside the #if block, the script does not compile on a Mac in the Unity editor and throws a bunch of errors which get solved with this small change. 

Errors fixed:
Assets/MRDesignLab/HUX/Scripts/Speech/KeywordManager.cs(266,23): error CS1519: Unexpected symbol `catch’ in class, struct, or interface member declaration
Assets/MRDesignLab/HUX/Scripts/Speech/KeywordManager.cs(266,44): error CS1519: Unexpected symbol `)' in class, struct, or interface member declaration
Assets/MRDesignLab/HUX/Scripts/Speech/KeywordManager.cs(266,46): error CS9010: Primary constructor body is not allowed
Assets/MRDesignLab/HUX/Scripts/Speech/KeywordManager.cs(417,0): error CS1525: Unexpected symbol `}'