### PR TITLE
Added null checks for hand input

### DIFF
--- a/HUX/Scripts/Input/InputSourceHands.cs
+++ b/HUX/Scripts/Input/InputSourceHands.cs
@@ -412,9 +412,10 @@ public class InputSourceHands : InputSourceBase, ITargetingInputSource
             Vector3 newPosition;
             if (state.properties.location.TryGetPosition(out newPosition)) {
                 CurrentHandState inputState = trackedHands.Find(CurrentInputState => CurrentInputState.HandId == state.source.id); // handID
-
-                UpdateFromWSASource(inputState, state);
-                SourceUpdate(inputState, newPosition);
+				if (inputState != null) {
+					UpdateFromWSASource(inputState, state);
+					SourceUpdate(inputState, newPosition);
+				}
             }
         }
     }
@@ -423,8 +424,10 @@ public class InputSourceHands : InputSourceBase, ITargetingInputSource
         if (state.source.kind == InteractionSourceKind.Hand) {
             CurrentHandState inputState = trackedHands.Find(CurrentInputState => CurrentInputState.HandId == state.source.id); // handID
 
-            UpdateFromWSASource(inputState, state);
-            SourceLost(inputState);
+			if (inputState != null) {
+				UpdateFromWSASource(inputState, state);
+				SourceLost(inputState);
+			}
         }
     }
 


### PR DESCRIPTION
Swapping from a non-HoloLens prefab camera to a HoloLens prefab camera causes a null reference error, this alleviates that.

I hit this issue tonight when messing around with a project with the actual HoloLens device itself (did not test in Unity for the same error). If you have a scene with the "HoloLensCamera" prefab that loads another scene with just the "HoloLens" prefab, a null reference error is thrown because the inputState isn't checked for null. I'm honestly not 100% sure what causes this to be null as I didn't dig too deep into it, but I know it has to do with the fact that trackedHands can sometimes be null, and that might be because of missing prefabs in a menu screen. I added in the null checks and the issues went away, and my program went on without a hitch that time around.