### PR TITLE
Send gameObject during SendMessageUpwards

### DIFF
--- a/HUX/Scripts/Buttons/CompoundButtonSpeech.cs
+++ b/HUX/Scripts/Buttons/CompoundButtonSpeech.cs
@@ -75,7 +75,7 @@ namespace HUX.Buttons
             // Send a pressed message to the button through the InteractionManager
             // (This will ensure InteractionReceivers also receive the event)
 
-            gameObject.SendMessageUpwards("OnTapped", SendMessageOptions.DontRequireReceiver);
+            gameObject.SendMessageUpwards("OnTapped", this.gameObject, SendMessageOptions.DontRequireReceiver);
         }
     }
 }


### PR DESCRIPTION
Without the gameObject, the InteractionReceiver cannot discern which Object originated the message easily. Adding this.gameObject will not break any existing functionality since any OnTapped() functions will still work and will just drop the argument.