### PR TITLE
Add Global Interaction Receiver to Interaction Manager

### DIFF
--- a/HUX/Editor/InteractionManagerInspector.cs
+++ b/HUX/Editor/InteractionManagerInspector.cs
@@ -27,6 +27,22 @@ namespace HUX
                 UnityEngine.VR.WSA.Input.GestureSettings.NavigationX | 
                 UnityEngine.VR.WSA.Input.GestureSettings.NavigationY);
 
+            EditorGUILayout.BeginHorizontal();
+            interactionManager.SendTapToGlobalReceiver = EditorGUILayout.Toggle("Send Tap to GlobalGestureReceiver", interactionManager.SendTapToGlobalReceiver);
+            EditorGUILayout.EndHorizontal();
+            if (interactionManager.SendTapToGlobalReceiver && (interactionManager.RecognizableGesures & UnityEngine.VR.WSA.Input.GestureSettings.Tap) == 0)
+                interactionManager.SendTapToGlobalReceiver = false;
+
+            EditorGUILayout.BeginHorizontal();
+            interactionManager.SendDoubleTapToGlobalReceiver = EditorGUILayout.Toggle("Send Double Tap to GlobalGestureReceiver", interactionManager.SendDoubleTapToGlobalReceiver);
+            EditorGUILayout.EndHorizontal();
+            if (interactionManager.SendDoubleTapToGlobalReceiver && (interactionManager.RecognizableGesures & UnityEngine.VR.WSA.Input.GestureSettings.DoubleTap) == 0)
+                interactionManager.SendDoubleTapToGlobalReceiver = false;
+
+            EditorGUILayout.BeginHorizontal();
+            interactionManager.GlobalGestureReceiver = (GameObject)EditorGUILayout.ObjectField("Global Gesture Receiver", interactionManager.GlobalGestureReceiver, typeof(GameObject), true);
+            EditorGUILayout.EndHorizontal();
+
             HUXEditorUtils.SaveChanges(target);
         }
     }

--- a/HUX/Scripts/Interaction/InteractionManager.cs
+++ b/HUX/Scripts/Interaction/InteractionManager.cs
@@ -62,6 +62,21 @@ namespace HUX.Interaction
         public GestureSettings RecognizableGesures = GestureSettings.Tap | GestureSettings.DoubleTap | GestureSettings.Hold | GestureSettings.NavigationX | GestureSettings.NavigationY;
 
         /// <summary>
+        /// GameObject that gestures events can optionally be sent to in addition to the regular interaction path
+        /// </summary>
+        public GameObject GlobalGestureReceiver;
+
+        /// <summary>
+        /// Whether to send OnTapped event to the GlobalGestureReceiver GameObject 
+        /// </summary>
+        public bool SendTapToGlobalReceiver = false;
+
+        /// <summary>
+        /// Whether to send OnDoubleTapped event to the GlobalGestureReceiver GameObject 
+        /// </summary>
+        public bool SendDoubleTapToGlobalReceiver = false;
+
+        /// <summary>
         /// Events that trigger manipulation or navigation is done on the specified object.
         /// </summary>
         public static event Action<GameObject, InteractionEventArgs> OnNavigationStarted;
@@ -538,6 +553,11 @@ namespace HUX.Interaction
                     focusObject.SendMessage("Tapped", eventArgs, SendMessageOptions.DontRequireReceiver);
                 }
 
+                if (SendTapToGlobalReceiver)
+                {
+                    SendEvent(OnTapped, GlobalGestureReceiver, eventArgs);
+                }
+
                 SendEvent(OnTapped, focusObject, eventArgs);
 
                 if (focuser.UIInteractibleFocus != null)
@@ -575,6 +595,11 @@ namespace HUX.Interaction
                 if (focusObject != null)
                 {
                     focusObject.SendMessage("DoubleTapped", eventArgs, SendMessageOptions.DontRequireReceiver);
+                }
+
+                if (SendDoubleTapToGlobalReceiver)
+                {
+                    SendEvent(OnDoubleTapped, GlobalGestureReceiver, eventArgs);
                 }
 
                 SendEvent(OnDoubleTapped, focusObject, eventArgs);


### PR DESCRIPTION
Add ability to send Tapped and DoubleTapped events to a global Interaction receiver GO in addition to the regular interaction path.

This is useful if you want to trigger something with the Clicker for example (like taking a picture) without going through the focus manager