### PR TITLE
Fixes for 2017.2.0f3

### DIFF
--- a/HUX/Editor/InteractionManagerInspector.cs
+++ b/HUX/Editor/InteractionManagerInspector.cs
@@ -17,15 +17,15 @@ namespace HUX
         {
             InteractionManager interactionManager = (InteractionManager)target;
 
-            interactionManager.RecognizableGesures = (UnityEngine.VR.WSA.Input.GestureSettings)HUXEditorUtils.EnumCheckboxField<UnityEngine.VR.WSA.Input.GestureSettings>(
+            interactionManager.RecognizableGesures = (UnityEngine.XR.WSA.Input.GestureSettings)HUXEditorUtils.EnumCheckboxField<UnityEngine.XR.WSA.Input.GestureSettings>(
                 "Recognizable gestures",
                 interactionManager.RecognizableGesures,
                 "Default",
-                UnityEngine.VR.WSA.Input.GestureSettings.Tap |
-                UnityEngine.VR.WSA.Input.GestureSettings.DoubleTap |
-                UnityEngine.VR.WSA.Input.GestureSettings.Hold | 
-                UnityEngine.VR.WSA.Input.GestureSettings.NavigationX | 
-                UnityEngine.VR.WSA.Input.GestureSettings.NavigationY);
+                UnityEngine.XR.WSA.Input.GestureSettings.Tap |
+                UnityEngine.XR.WSA.Input.GestureSettings.DoubleTap |
+                UnityEngine.XR.WSA.Input.GestureSettings.Hold | 
+                UnityEngine.XR.WSA.Input.GestureSettings.NavigationX | 
+                UnityEngine.XR.WSA.Input.GestureSettings.NavigationY);
 
            HUXEditorUtils.SaveChanges(target, serializedObject);
         }

--- a/HUX/Prefabs/Dialogs/BoundingBoxShell.prefab.meta
+++ b/HUX/Prefabs/Dialogs/BoundingBoxShell.prefab.meta
@@ -1,8 +1,10 @@
 fileFormatVersion: 2
-guid: cd435fa946a12fb42b7fe3f3e3bd24dc
+guid: 76ede5da4cb0a42e2b7019525ebbbeae
 timeCreated: 1450231244
 licenseType: Pro
 NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/HUX/Scripts/Core/Veil.cs
+++ b/HUX/Scripts/Core/Veil.cs
@@ -241,7 +241,7 @@ namespace HUX
             switch (CurrentDevice)
             {
                 case DeviceTypeEnum.Auto:
-                switch (VRSettings.loadedDeviceName)
+                switch (UnityEngine.XR.XRSettings.loadedDeviceName)
                 {
                     case "Oculus":
                     m_deviceFOV = OCULUS_FOV;
@@ -307,9 +307,9 @@ namespace HUX
 #if UNITY_EDITOR || !UNITY_WSA
                 if (SetVeilFOVOnStartInEditor)
                 {
-                    if (VRDevice.isPresent)
+                    if (UnityEngine.XR.XRDevice.isPresent)
                     {
-                        while (!VRSettings.enabled)
+                        while (!UnityEngine.XR.XRSettings.enabled)
                         {
                             yield return null;
                         }

--- a/HUX/Scripts/Dialogs/Debug/DebugLog.cs
+++ b/HUX/Scripts/Dialogs/Debug/DebugLog.cs
@@ -385,7 +385,7 @@ namespace HUX.Dialogs.Debug
             Application.logMessageReceived += HandleLog;
             s_DebugOutputs.Add(this);
 
-            if (m_DebugLogObj && (UnityEngine.VR.VRSettings.loadedDeviceName == "Oculus" || UnityEngine.VR.VRSettings.loadedDeviceName == "OpenVR"))
+            if (m_DebugLogObj && (UnityEngine.XR.XRSettings.loadedDeviceName == "Oculus" || UnityEngine.XR.XRSettings.loadedDeviceName == "OpenVR"))
             {
                 // Scale up
                 RectTransform rectTransform = m_DebugLogObj.GetComponent<RectTransform>();

--- a/HUX/Scripts/Dialogs/Debug/DebugMenu.cs
+++ b/HUX/Scripts/Dialogs/Debug/DebugMenu.cs
@@ -239,7 +239,7 @@ namespace HUX.Dialogs.Debug
                 gameObject.AddComponent<DebugMenuAttributeList>();
             }
 
-            if (m_MenuContainer && (UnityEngine.VR.VRSettings.loadedDeviceName == "Oculus" || UnityEngine.VR.VRSettings.loadedDeviceName == "OpenVR"))
+            if (m_MenuContainer && (UnityEngine.XR.XRSettings.loadedDeviceName == "Oculus" || UnityEngine.XR.XRSettings.loadedDeviceName == "OpenVR"))
             {
                 // Scale up -- We have to do this every time the page is dirty.
                 transform.localScale = Vector3.one * m_ScaleForHMD;

--- a/HUX/Scripts/Interaction/InteractionManager.cs
+++ b/HUX/Scripts/Interaction/InteractionManager.cs
@@ -7,7 +7,7 @@ using System;
 using HUX.Utility;
 using UnityEngine.EventSystems;
 using HUX.Focus;
-using UnityEngine.VR.WSA.Input;
+
 
 namespace HUX.Interaction
 {
@@ -36,9 +36,9 @@ namespace HUX.Interaction
         /// <summary>
         /// Currently active gesture recognizer.
         /// </summary>
-        public GestureRecognizer ActiveRecognizer { get; private set; }
+        public UnityEngine.XR.WSA.Input.GestureRecognizer ActiveRecognizer { get; private set; }
 
-		public UnityEngine.VR.WSA.Input.InteractionManager ActiveInteractionManager { get; private set; }
+		public UnityEngine.XR.WSA.Input.InteractionManager ActiveInteractionManager { get; private set; }
 
         /// <summary>
         /// is the user currently navigating.
@@ -59,7 +59,7 @@ namespace HUX.Interaction
         /// <summary>
         /// Which gestures the interaction manager's active recognizer will capture
         /// </summary>
-        public GestureSettings RecognizableGesures = GestureSettings.Tap | GestureSettings.DoubleTap | GestureSettings.Hold | GestureSettings.NavigationX | GestureSettings.NavigationY;
+        public UnityEngine.XR.WSA.Input.GestureSettings RecognizableGesures = UnityEngine.XR.WSA.Input.GestureSettings.Tap | UnityEngine.XR.WSA.Input.GestureSettings.DoubleTap | UnityEngine.XR.WSA.Input.GestureSettings.Hold | UnityEngine.XR.WSA.Input.GestureSettings.NavigationX | UnityEngine.XR.WSA.Input.GestureSettings.NavigationY;
 
         /// <summary>
         /// Events that trigger manipulation or navigation is done on the specified object.
@@ -105,7 +105,7 @@ namespace HUX.Interaction
 		// This should be Start instead of Awake right?
 		protected void Start()
         {
-            ActiveRecognizer = new GestureRecognizer();
+            ActiveRecognizer = new UnityEngine.XR.WSA.Input.GestureRecognizer();
 
             ActiveRecognizer.SetRecognizableGestures(RecognizableGesures);
 
@@ -128,21 +128,21 @@ namespace HUX.Interaction
             ActiveRecognizer.StartCapturingGestures();
             SetupEvents(true);
 
-			UnityEngine.VR.WSA.Input.InteractionManager.SourcePressed += InteractionManager_SourcePressedCallback;
-			UnityEngine.VR.WSA.Input.InteractionManager.SourceReleased += InteractionManager_SourceReleasedCallback;
+            UnityEngine.XR.WSA.Input.InteractionManager.InteractionSourcePressed += InteractionManager_SourcePressedCallback;
+            UnityEngine.XR.WSA.Input.InteractionManager.InteractionSourceReleased += InteractionManager_SourceReleasedCallback;
 
 			bLockFocus = true;
 		}
 
-		private void InteractionManager_SourcePressedCallback(InteractionSourceState state)
+        private void InteractionManager_SourcePressedCallback(UnityEngine.XR.WSA.Input.InteractionSourcePressedEventArgs args)
 		{
-			AFocuser focuser = GetFocuserForSource(state.source.kind);
+            AFocuser focuser = GetFocuserForSource(args.state.source.kind);
 			OnPressedEvent(focuser);
 		}
 
-		private void InteractionManager_SourceReleasedCallback(InteractionSourceState state)
+        private void InteractionManager_SourceReleasedCallback(UnityEngine.XR.WSA.Input.InteractionSourceReleasedEventArgs args)
 		{
-			AFocuser focuser = GetFocuserForSource(state.source.kind);
+            AFocuser focuser = GetFocuserForSource(args.state.source.kind);
 			OnReleasedEvent(focuser);
 		}
 
@@ -153,7 +153,7 @@ namespace HUX.Interaction
 			// Only do manipulation event simulation in editor, and should we do it on PC?
 			if (Application.platform == RuntimePlatform.WindowsEditor /*|| Application.platform == RuntimePlatform.WindowsPlayer*/)
 			{
-				AFocuser focuser = GetFocuserForSource(InteractionSourceKind.Hand);
+				AFocuser focuser = GetFocuserForSource(UnityEngine.XR.WSA.Input.InteractionSourceKind.Hand);
 
 				// Use the head's position + forward, since the focuser ray might point to the locked focus
 				Vector3 newPos = Veil.Instance.HeadTransform.position + Veil.Instance.HeadTransform.forward;
@@ -326,18 +326,18 @@ namespace HUX.Interaction
         }
 
 
-		private AFocuser GetFocuserForSource(InteractionSourceKind source)
+		private AFocuser GetFocuserForSource(UnityEngine.XR.WSA.Input.InteractionSourceKind source)
 		{
 			AFocuser focuser = FocusManager.Instance != null ? FocusManager.Instance.GazeFocuser : null;
 			switch (source)
 			{
-				case InteractionSourceKind.Hand:
+				case UnityEngine.XR.WSA.Input.InteractionSourceKind.Hand:
 				{
 					focuser = InputSourceFocuser.GetFocuserForInputSource(InputSources.Instance.hands);
 					break;
 				}
 
-				case InteractionSourceKind.Controller:
+				case UnityEngine.XR.WSA.Input.InteractionSourceKind.Controller:
 				{
 					focuser = InputSourceFocuser.GetFocuserForInputSource(InputSources.Instance.sixDOFRay);
 					break;
@@ -847,7 +847,7 @@ namespace HUX.Interaction
         #endregion
 
         #region Gesture Recognizer Callbacks
-        private void NavigationStartedCallback(InteractionSourceKind source, Vector3 relativePosition, Ray ray)
+        private void NavigationStartedCallback(UnityEngine.XR.WSA.Input.InteractionSourceKind source, Vector3 relativePosition, Ray ray)
         {
 			AFocuser focuser = GetFocuserForSource(source);
 			if (focuser != null)
@@ -856,7 +856,7 @@ namespace HUX.Interaction
             }
         }
 
-        private void NavigationUpdatedCallback(InteractionSourceKind source, Vector3 relativePosition, Ray ray)
+        private void NavigationUpdatedCallback(UnityEngine.XR.WSA.Input.InteractionSourceKind source, Vector3 relativePosition, Ray ray)
         {
 			AFocuser focuser = GetFocuserForSource(source);
 			if (focuser != null)
@@ -865,7 +865,7 @@ namespace HUX.Interaction
             }
         }
 
-        private void NavigationCompletedCallback(InteractionSourceKind source, Vector3 relativePosition, Ray ray)
+        private void NavigationCompletedCallback(UnityEngine.XR.WSA.Input.InteractionSourceKind source, Vector3 relativePosition, Ray ray)
         {
 			AFocuser focuser = GetFocuserForSource(source);
 			if (focuser != null)
@@ -874,7 +874,7 @@ namespace HUX.Interaction
             }
         }
 
-        private void NavigationCanceledCallback(InteractionSourceKind source, Vector3 relativePosition, Ray ray)
+        private void NavigationCanceledCallback(UnityEngine.XR.WSA.Input.InteractionSourceKind source, Vector3 relativePosition, Ray ray)
         {
 			AFocuser focuser = GetFocuserForSource(source);
 			if (focuser != null)
@@ -883,7 +883,7 @@ namespace HUX.Interaction
             }
         }
 
-        private void TappedCallback(InteractionSourceKind source, int tapCount, Ray ray)
+        private void TappedCallback(UnityEngine.XR.WSA.Input.InteractionSourceKind source, int tapCount, Ray ray)
         {
 			AFocuser focuser = GetFocuserForSource(source);
             if (focuser != null)
@@ -899,7 +899,7 @@ namespace HUX.Interaction
             }
         }
 
-        private void HoldStartedCallback(InteractionSourceKind source, Ray ray)
+        private void HoldStartedCallback(UnityEngine.XR.WSA.Input.InteractionSourceKind source, Ray ray)
         {
 			AFocuser focuser = GetFocuserForSource(source);
 			if (focuser != null)
@@ -908,7 +908,7 @@ namespace HUX.Interaction
             }
         }
 
-        private void HoldCompletedCallback(InteractionSourceKind source, Ray ray)
+        private void HoldCompletedCallback(UnityEngine.XR.WSA.Input.InteractionSourceKind source, Ray ray)
         {
 			AFocuser focuser = GetFocuserForSource(source);
 			if (focuser != null)
@@ -917,7 +917,7 @@ namespace HUX.Interaction
             }
         }
 
-        private void HoldCanceledCallback(InteractionSourceKind source, Ray ray)
+        private void HoldCanceledCallback(UnityEngine.XR.WSA.Input.InteractionSourceKind source, Ray ray)
         {
 			AFocuser focuser = GetFocuserForSource(source);
 			if (focuser != null)
@@ -926,7 +926,7 @@ namespace HUX.Interaction
             }
         }
 
-        private void ManipulationStartedCallback(InteractionSourceKind source, Vector3 position, Ray ray)
+        private void ManipulationStartedCallback(UnityEngine.XR.WSA.Input.InteractionSourceKind source, Vector3 position, Ray ray)
         {
 			AFocuser focuser = GetFocuserForSource(source);
 			if (focuser != null)
@@ -935,7 +935,7 @@ namespace HUX.Interaction
             }
         }
 
-        private void ManipulationUpdatedCallback(InteractionSourceKind source, Vector3 position, Ray ray)
+        private void ManipulationUpdatedCallback(UnityEngine.XR.WSA.Input.InteractionSourceKind source, Vector3 position, Ray ray)
         {
 			AFocuser focuser = GetFocuserForSource(source);
 			if (focuser != null)
@@ -944,7 +944,7 @@ namespace HUX.Interaction
             }
         }
 
-        private void ManipulationCompletedCallback(InteractionSourceKind source, Vector3 position, Ray ray)
+        private void ManipulationCompletedCallback(UnityEngine.XR.WSA.Input.InteractionSourceKind source, Vector3 position, Ray ray)
         {
 			AFocuser focuser = GetFocuserForSource(source);
 			if (focuser != null)
@@ -953,7 +953,7 @@ namespace HUX.Interaction
             }
         }
 
-        private void ManipulationCanceledCallback(InteractionSourceKind source, Vector3 position, Ray ray)
+        private void ManipulationCanceledCallback(UnityEngine.XR.WSA.Input.InteractionSourceKind source, Vector3 position, Ray ray)
         {
 			AFocuser focuser = GetFocuserForSource(source);
 			if (focuser != null)

--- a/HUX/Scripts/Spatial/Planes/SurfacePlaneManager.cs
+++ b/HUX/Scripts/Spatial/Planes/SurfacePlaneManager.cs
@@ -10,7 +10,7 @@ using HUX.Utility;
 using HoloToolkit.Unity.SpatialMapping;
 
 #if UNITY_WSA
-using UnityEngine.VR.WSA;
+using UnityEngine.XR.WSA;
 #endif
 
 #if UNITY_WSA && !UNITY_EDITOR

--- a/HUX/Scripts/Spatial/PointOfReferenceManager.cs
+++ b/HUX/Scripts/Spatial/PointOfReferenceManager.cs
@@ -5,9 +5,9 @@
 using UnityEngine;
 
 #if UNITY_WSA
-using UnityEngine.VR.WSA;
-using UnityEngine.VR.WSA.Persistence;
-using UnityEngine.VR.WSA.Sharing;
+
+
+
 #endif
 
 using System.Collections;
@@ -24,9 +24,9 @@ public class PointOfReferenceManager : Singleton<PointOfReferenceManager>
 #if UNITY_WSA
     List<string> m_MessagesAsync = new List<string>();
     public event System.Action OnPlacement;
-    WorldAnchorStore store = null;
-    private WorldAnchor m_PointOfReference = null;
-    public WorldAnchor PointOfReference
+    UnityEngine.XR.WSA.Persistence.WorldAnchorStore store = null;
+    private UnityEngine.XR.WSA.WorldAnchor m_PointOfReference = null;
+    public UnityEngine.XR.WSA.WorldAnchor PointOfReference
     {
         get { return m_PointOfReference; }
     }
@@ -102,7 +102,7 @@ public class PointOfReferenceManager : Singleton<PointOfReferenceManager>
             DestroyImmediate(m_PointOfReference);
         }
 
-        m_PointOfReference = m_PointOfReferenceCube.AddComponent<WorldAnchor>();
+        m_PointOfReference = m_PointOfReferenceCube.AddComponent<UnityEngine.XR.WSA.WorldAnchor>();
         if (StatusText.Instance)
         {
             StatusText.Instance.SetText("Point of Reference Created");
@@ -123,7 +123,7 @@ public class PointOfReferenceManager : Singleton<PointOfReferenceManager>
         }
     }
 
-    private void StoreLoaded(WorldAnchorStore store)
+    private void StoreLoaded(UnityEngine.XR.WSA.Persistence.WorldAnchorStore store)
     {
         this.store = store;
 
@@ -177,7 +177,7 @@ public class PointOfReferenceManager : Singleton<PointOfReferenceManager>
         Debug.Log("SaveAnchor: Point of Reference Saved.");
     }
 
-    private void SaveAnchorToStore(string id, WorldAnchor worldAnchor)
+    private void SaveAnchorToStore(string id, UnityEngine.XR.WSA.WorldAnchor worldAnchor)
     {
 #if !UNITY_EDITOR
         if ((store != null) && (store.Save(id, worldAnchor)))
@@ -206,12 +206,12 @@ public class PointOfReferenceManager : Singleton<PointOfReferenceManager>
 
     public void SetPointOfReference(byte[] pointOfReferenceData)
     {
-        WorldAnchorTransferBatch.ImportAsync(pointOfReferenceData, OnImportComplete);
+        UnityEngine.XR.WSA.Sharing.WorldAnchorTransferBatch.ImportAsync(pointOfReferenceData, OnImportComplete);
     }
 
-    private void OnImportComplete(SerializationCompletionReason completionReason, WorldAnchorTransferBatch deserializedTransferBatch)
+    private void OnImportComplete(UnityEngine.XR.WSA.Sharing.SerializationCompletionReason completionReason, UnityEngine.XR.WSA.Sharing.WorldAnchorTransferBatch deserializedTransferBatch)
     {
-        if (completionReason != SerializationCompletionReason.Succeeded)
+        if (completionReason != UnityEngine.XR.WSA.Sharing.SerializationCompletionReason.Succeeded)
         {
             LogAsync("Failed to import: " + completionReason.ToString());
             return;

--- a/HUX/Scripts/Spatial/PointOfReferenceManager.cs
+++ b/HUX/Scripts/Spatial/PointOfReferenceManager.cs
@@ -61,7 +61,7 @@ public class PointOfReferenceManager : Singleton<PointOfReferenceManager>
 #if UNITY_EDITOR
         m_LoadedAndPlaced = true;
 #else
-        WorldAnchorStore.GetAsync(StoreLoaded);
+        UnityEngine.XR.WSA.Persistence.WorldAnchorStore.GetAsync(StoreLoaded);
 #endif
         
 		InputSources.Instance.hands.OnFingerPressed += OnFingerPressed;

--- a/HUX/Scripts/Utility/ManualCameraControl.cs
+++ b/HUX/Scripts/Utility/ManualCameraControl.cs
@@ -79,9 +79,9 @@ public class ManualCameraControl : MonoBehaviour
         m_InitialRotation = m_Veil.transform.rotation;
 
         // VR Mode
-        if (VRSettings.loadedDeviceName == "Oculus" || VRSettings.loadedDeviceName == "PlayStationVR")
+        if (UnityEngine.XR.XRSettings.loadedDeviceName == "Oculus" || UnityEngine.XR.XRSettings.loadedDeviceName == "PlayStationVR")
         {
-            InputTracking.Recenter();
+            UnityEngine.XR.InputTracking.Recenter();
         }
     }
 


### PR DESCRIPTION
These changes were mostly autogenerated by Unity when upgrading to 2017.2.0f3. The only exception is in the InteractionManager, where I had to make manual changes to the InteractionManager_SourcePressedCallback and InteractionManager_SourceReleasedCallback to accommodate the upgrade.

I later found additional fixes I needed to make by hand in the same way to 
HUX/Scripts/Input/InputSourceHands.cs
HUX/Scripts/Spatial/Planes/SurfacePlaneManager.cs
HUX/Scripts/Spatial/PointOfReferenceManager.cs